### PR TITLE
Develop

### DIFF
--- a/R/data_table_interface_generics.R
+++ b/R/data_table_interface_generics.R
@@ -80,7 +80,6 @@ names.datatableinterface <- function(x) {
     }
 
     col_name <- table_proxy_colnames(tproxy)[as.integer(j[1])]
-
     # tproxy <- .tproxy(x)
     #
     # return(rtable_read_range(tproxy, from = j[2], to = j[2],  colnames = col_name))
@@ -104,8 +103,7 @@ names.datatableinterface <- function(x) {
   }
 
   # determine row selection here from metadata
-
-  # rproxy_read_full(tproxy, j)
+  table_proxy_read_full(tproxy, j)
 }
 
 

--- a/R/table_proxy_methods.R
+++ b/R/table_proxy_methods.R
@@ -80,7 +80,7 @@ table_proxy_read_range <- function(tbl_proxy, from_row, to_row, col_names = NULL
 }
 
 
-table_proxy_read_full <- function(tbl_proxy, colnames = NULL) {
+table_proxy_read_full <- function(tbl_proxy, col_names = NULL) {
 
   # use the remotetablestate to get a subset of the data in memory
   rtable_state <- tbl_proxy$remotetablestate


### PR DESCRIPTION
Another tiny commit to restore some data.table functionality. 

If I understand the 3-level interface correctly, aside from recursive indexing, no further code would be required in [[.datatableinterface* as the rows to return will be determined by the the table_proxy (via its current state.)