### PR TITLE
Implement [[ for data.table interface using table_proxy

### DIFF
--- a/R/data_table_interface_generics.R
+++ b/R/data_table_interface_generics.R
@@ -80,7 +80,6 @@ names.datatableinterface <- function(x) {
     }
 
     col_name <- table_proxy_colnames(tproxy)[as.integer(j[1])]
-
     # tproxy <- .tproxy(x)
     #
     # return(rtable_read_range(tproxy, from = j[2], to = j[2],  colnames = col_name))
@@ -102,10 +101,8 @@ names.datatableinterface <- function(x) {
       return(NULL)
     }
   }
-
-  # determine row selection here from metadata
-
-  # rproxy_read_full(tproxy, j)
+  
+  return(table_proxy_read_full(tproxy, j)[[1]])
 }
 
 

--- a/R/table_proxy_methods.R
+++ b/R/table_proxy_methods.R
@@ -80,7 +80,7 @@ table_proxy_read_range <- function(tbl_proxy, from_row, to_row, col_names = NULL
 }
 
 
-table_proxy_read_full <- function(tbl_proxy, colnames = NULL) {
+table_proxy_read_full <- function(tbl_proxy, col_names = NULL) {
 
   # use the remotetablestate to get a subset of the data in memory
   rtable_state <- tbl_proxy$remotetablestate


### PR DESCRIPTION
Another small commit to restore some data.table functionality.

Disregarding recursive indexing, I believe this is the complete implementation of [[.datatableinterface, as the rows to return are determined by the table_proxy.

(Sorry for the pull request spam, I was in a hurry and kept pushing the wrong version.)