### PR TITLE
Rough implementation of row_filter & slice_map

### DIFF
--- a/R/data_table_interface.R
+++ b/R/data_table_interface.R
@@ -92,7 +92,18 @@ data_table_interface <- function(table_proxy) {
   if (!missing(i)) {
     if (verbose) print("i used")
 
-    # return full table, implement later
+    if (is.logical(i)) {
+
+      if (nrow(x) != length(i)) {
+        stop(paste('i evaluates to a logical vector length', length(i), 'but there are', nrow(x) ,'rows.',
+                   'Recycling of logical i is not allowed with data.tables.'))
+      }
+
+      i <- base::which(i)
+    }
+
+    table_proxy <- table_proxy_select_rows(table_proxy, i)
+
     return(data_table_interface(table_proxy))
   }
 

--- a/R/data_table_interface.R
+++ b/R/data_table_interface.R
@@ -42,7 +42,7 @@ data_table_interface <- function(table_proxy) {
   nr_of_display_cols <- min(length(proxy_colnames), 50)
 
   dt <- data.table::as.data.table(matrix(rep(0, 1 + nr_of_display_cols), nrow = 1))
-  colnames(dt) <- c(".table_proxy", proxy_colnames[1:nr_of_display_cols])
+  data.table::setnames(dt, c(".table_proxy", proxy_colnames[1:nr_of_display_cols]))
 
   # store remote proxy object
   dt[, .table_proxy := list(list(table_proxy))]

--- a/R/table_proxy.R
+++ b/R/table_proxy.R
@@ -46,7 +46,10 @@ table_proxy <- function(remote_table) {
     colnames = proxy_colnames,
     coltypes = rtable_column_types(remote_table),
     nrow = rtable_nrow(remote_table),
-    ncol = length(proxy_colnames)
+    ncol = length(proxy_colnames),
+
+    row_filter = rep(TRUE, rtable_nrow(remote_table)),
+    slice_map = 1:rtable_nrow(remote_table)
   )
 
   .table_proxy(remote_table, remote_table_state)


### PR DESCRIPTION
A naive implementation of the filter & slicemap, entirely in R. Nothing here has been optimized for grace or efficiency, but I think it more or less captures the concepts in #22 and #25.

Here's a demo/test:
```
tmp <- tempfile()
fst::write_fst(data.table::data.table(a = 1:100), tmp)
ft <- fsttable::fst_table(tmp)

ft[c(1,9,2,5,10)] # prints original rows 1,9,2,5,10

ft[10:30] # prints original rows 10-30
ft[10:30][c(1,3)] # prints original rows 10 & 12
ft[10:30][20:10] # prints original rows 29-19
ft[10:30][20:10][c(2,4)] # prints original rows 28 & 26

ft # prints original rows 1-5 -- 96-100
ft[40:100] # print original rows 40-44 -- 96-100
ft[100:20] # prints original rows 100-96 -- 24-20
ft[c(100:20, 1)] # prints original rows 100-96 -- 23-20,1
```