### PR TITLE
Make full selections of fsttable return identical tables

### DIFF
--- a/R/table_proxy_methods.R
+++ b/R/table_proxy_methods.R
@@ -164,6 +164,11 @@ table_proxy_select_row_mask <- function(tbl_proxy, i) {
   # In the current implementation, the table proxy state can contain only a single
   # row selection filter. This method will apply filter i to the existing slice map.
 
+  # if full selection, don't alter table state
+  if (all(i)) {
+    return(tbl_proxy)
+  }
+
   # current slice map
   slice_map <- tbl_proxy$remotetablestate$slice_map
 
@@ -186,7 +191,7 @@ table_proxy_select_row_mask <- function(tbl_proxy, i) {
 
 
 #' Apply a row-selection operation on the current table_proxy state
-#' This operation could change the slice map ordering  
+#' This operation could change the slice map ordering
 #'
 #' @param tbl_proxy a table proxy object
 #' @param i an integer vector with the selected rows
@@ -200,6 +205,11 @@ table_proxy_select_rows <- function(tbl_proxy, i) {
 
   # current slice map
   slice_map <- tbl_proxy$remotetablestate$slice_map
+
+  # if full ordered selection, don't alter table state
+  if (identical(i, seq(1, tbl_proxy$remotetablestate$nrow))) {
+    return(tbl_proxy)
+  }
 
   # set equal to selected slice map
   # slice map ordering does not change

--- a/tests/testthat/test_interface.R
+++ b/tests/testthat/test_interface.R
@@ -22,10 +22,13 @@ check_interface <- function(ft, dt, i, j) {
   expect_equal(ft[i, j, collect = TRUE], dt[i, j])
 }
 
+expect_identical_table_proxy <- function(ft1, ft2) {
+  expect_identical(fsttable:::.get_table_proxy(ft1), fsttable:::.get_table_proxy(ft2))
+}
 
 test_that("empty i and j", {
   ft_copy <- ft[]
-  expect_identical(ft, ft_copy)
+  expect_identical_table_proxy(ft, ft_copy)
 })
 
 
@@ -39,4 +42,9 @@ test_that("row selection", {
 
   # incorrect logical length
   expect_error(ft[c(TRUE, FALSE)], "Recycling of logical i is not allowed with data.table")
+
+  # full selection should return identical table
+  expect_identical_table_proxy(ft, ft[1:nrow(ft)])
+  expect_identical_table_proxy(ft, ft[rep(TRUE, nrow(ft))])
+
 })


### PR DESCRIPTION
This addresses #33, increases efficiency, and keeps a NULL slice map for fsttables that map to entire tables on disk.